### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/version-and-release.yaml
+++ b/.github/workflows/version-and-release.yaml
@@ -63,11 +63,11 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
-            const content = fs.readFileSync('CHANGELOG.md', 'utf8');
+            const content = fs.readFileSync('packages/api/CHANGELOG.md', 'utf8');
             const lines = content.split('\n');
             let start = -1, end = -1;
             for (let i = 0; i < lines.length; i++) {
-              if (/^## \[/.test(lines[i])) {
+              if (/^## v?\d+\.\d+\.\d+/.test(lines[i])) {
                 if (start === -1) start = i;
                 else { end = i; break; }
               }


### PR DESCRIPTION
The version-and-release workflow (runs on push to main) read the root CHANGELOG.md, but 'npx changeset version' writes per-package changelogs (packages/api/CHANGELOG.md), so the step failed with ENOENT on every staging->main merge. Point it at packages/api/CHANGELOG.md and fix the version-header regex to match changesets' actual '## 0.2.0' format instead of the never-matching '## [0.2.0]'.